### PR TITLE
Add restrictions to wildcard generics

### DIFF
--- a/src/main/java/org/visab/api/SessionWatchdog.java
+++ b/src/main/java/org/visab/api/SessionWatchdog.java
@@ -21,8 +21,7 @@ import org.visab.util.Settings;
  * @author moritz
  *
  */
-public class SessionWatchdog extends SubscriberBase<StatisticsReceivedEvent>
-        implements IPublisher<SessionClosedEvent> {
+public class SessionWatchdog extends SubscriberBase<StatisticsReceivedEvent> implements IPublisher<SessionClosedEvent> {
 
     private static Map<UUID, String> activeSessions = new HashMap<>();
 
@@ -91,6 +90,7 @@ public class SessionWatchdog extends SubscriberBase<StatisticsReceivedEvent>
      * After that a SessionClosedEvent is published.
      */
     private void checkSessionTimeouts() {
+        // Make a copy because of potential modification during iteration
         var entries = new ArrayList<Entry<UUID, LocalTime>>();
         entries.addAll(statisticsSentTimes.entrySet());
 

--- a/src/main/java/org/visab/eventbus/ApiEventBus.java
+++ b/src/main/java/org/visab/eventbus/ApiEventBus.java
@@ -14,7 +14,7 @@ import java.util.Map;
  */
 public class ApiEventBus {
 
-    private Map<String, ArrayList<ISubscriber<?>>> subscribers = new HashMap<>();
+    private Map<String, ArrayList<ISubscriber<? extends IEvent>>> subscribers = new HashMap<>();
 
     public <TEvent extends IEvent> void publish(TEvent event) {
         var eventType = event.getClass().getSimpleName().toString();
@@ -28,7 +28,7 @@ public class ApiEventBus {
         }
     }
 
-    public void subscribe(ISubscriber<?> subscriber) {
+    public void subscribe(ISubscriber<? extends IEvent> subscriber) {
         var eventType = subscriber.getSubscribedEventType();
 
         if (!subscribers.containsKey(eventType))
@@ -36,7 +36,7 @@ public class ApiEventBus {
         subscribers.get(eventType).add(subscriber);
     }
 
-    public void unsubscribe(ISubscriber<?> subscriber) {
+    public void unsubscribe(ISubscriber<? extends IEvent> subscriber) {
         var eventType = subscriber.getSubscribedEventType();
 
         if (subscribers.containsKey(eventType))
@@ -56,9 +56,9 @@ public class ApiEventBus {
      */
     @SuppressWarnings("unchecked")
     private <TEvent extends IEvent> List<ISubscriber<TEvent>> castSubscribers(
-            List<ISubscriber<?>> uncastedSubscribers) {
+            List<ISubscriber<? extends IEvent>> uncastedSubscribers) {
         var casted = new ArrayList<ISubscriber<TEvent>>();
-        
+
         for (var sub : uncastedSubscribers)
             casted.add((ISubscriber<TEvent>) sub);
 

--- a/src/main/java/org/visab/processing/SessionListenerAdministration.java
+++ b/src/main/java/org/visab/processing/SessionListenerAdministration.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
  */
 public class SessionListenerAdministration {
 
-    private static List<ISessionListener<?>> activeListeners = new ArrayList<>();
+    private static List<ISessionListener<? extends IStatistics>> activeListeners = new ArrayList<>();
 
     /**
      * Returns a list of the currently active listeners. Warning: Does not return
@@ -23,11 +23,11 @@ public class SessionListenerAdministration {
      * 
      * @return A copy of the currently active listeners
      */
-    public static List<ISessionListener<?>> getActiveListeners() {
-        return new ArrayList<ISessionListener<?>>(activeListeners);
+    public static List<ISessionListener<? extends IStatistics>> getActiveListeners() {
+        return new ArrayList<ISessionListener<? extends IStatistics>>(activeListeners);
     }
 
-    public static ISessionListener<?> getSessionListener(UUID sessionId) {
+    public static ISessionListener<? extends IStatistics> getSessionListener(UUID sessionId) {
         for (var listener : activeListeners) {
             if (listener.getSessionId().equals(sessionId))
                 return listener;
@@ -36,16 +36,16 @@ public class SessionListenerAdministration {
         return null;
     }
 
-    public static List<ISessionListener<?>> getActiveListeners(String game) {
+    public static List<ISessionListener<? extends IStatistics>> getActiveListeners(String game) {
         return activeListeners.stream().filter(x -> x.getGame() == game).collect(Collectors.toList());
     }
 
-    public static void addListener(ISessionListener<?> listener) {
+    public static void addListener(ISessionListener<? extends IStatistics> listener) {
         activeListeners.add(listener);
     }
 
     // TODO: Remove gracefully?
-    public static void removeListener(ISessionListener<?> listener) {
+    public static void removeListener(ISessionListener<? extends IStatistics> listener) {
         activeListeners.remove(listener);
     }
 }

--- a/src/main/java/org/visab/processing/SessionListenerBase.java
+++ b/src/main/java/org/visab/processing/SessionListenerBase.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.visab.api.WebApi;
+import org.visab.eventbus.IEvent;
 import org.visab.eventbus.ISubscriber;
 import org.visab.eventbus.event.SessionClosedEvent;
 import org.visab.eventbus.event.StatisticsReceivedEvent;
@@ -90,7 +91,7 @@ public abstract class SessionListenerBase<TStatistics extends IStatistics> imple
      * List of all subscribers. All subscribers in this list will be unsubscribed on
      * the SessionClosedEvent.
      */
-    protected List<ISubscriber<?>> subscribers = new ArrayList<>();
+    protected List<ISubscriber<? extends IEvent>> subscribers = new ArrayList<>();
 
     public SessionListenerBase(String game, UUID sessionId) {
         this.game = game;

--- a/src/main/java/org/visab/util/AssignByGame.java
+++ b/src/main/java/org/visab/util/AssignByGame.java
@@ -19,6 +19,7 @@ import org.visab.repository.IVISABFile;
  * objects.
  *
  * TODO: Add default implementations
+ * 
  * @author moritz
  *
  */
@@ -46,10 +47,10 @@ public final class AssignByGame {
      */
     public static final IVISABFile getDeserializedFile(String json, String game) {
         switch (game) {
-            case CBR_SHOOTER_STRING:
-                return JsonConvert.deserializeJson(json, CBRShooterFile.class);
-            default:
-                return null;
+        case CBR_SHOOTER_STRING:
+            return JsonConvert.deserializeJson(json, CBRShooterFile.class);
+        default:
+            return null;
         }
     }
 
@@ -63,18 +64,18 @@ public final class AssignByGame {
     public static final IStatistics getDeserializedStatistics(String json, String game) { // throws
         // GameNotSupportedException
         switch (game) {
-            case CBR_SHOOTER_STRING:
-                return JsonConvert.deserializeJson(json, CBRShooterStatistics.class);
-            default:
-                return null;
-            // throw new GameNotSupportedException(String.format("Game {1,string} is not
-            // supported by VISAB yet.", game));
+        case CBR_SHOOTER_STRING:
+            return JsonConvert.deserializeJson(json, CBRShooterStatistics.class);
+        default:
+            return null;
+        // throw new GameNotSupportedException(String.format("Game {1,string} is not
+        // supported by VISAB yet.", game));
         }
     }
 
     /**
-     * TODO: instantiate by game
-     * Creates an map image object based on json data and the game.
+     * TODO: instantiate by game Creates an map image object based on json data and
+     * the game.
      *
      * @param json The json data to fill the object with
      * @param game The game
@@ -82,8 +83,8 @@ public final class AssignByGame {
      */
     public static final IMapImage getDeserializedMapImage(String json, String game) {
         switch (game) {
-            default:
-                return null;
+        default:
+            return null;
         }
     }
 
@@ -94,13 +95,13 @@ public final class AssignByGame {
      * @param sessionId The sessionId for the Listener to listen to
      * @return The SessionListener object
      */
-    public static final ISessionListener<?> getListenerInstanceByGame(String game, UUID sessionId) {
+    public static final ISessionListener<? extends IStatistics> getListenerInstanceByGame(String game, UUID sessionId) {
         switch (game) {
-            case CBR_SHOOTER_STRING:
-                return new CBRShooterListener(sessionId);
-            default:
-                // TODO: Raise exception
-                return null;
+        case CBR_SHOOTER_STRING:
+            return new CBRShooterListener(sessionId);
+        default:
+            // TODO: Raise exception
+            return null;
         }
     }
 }


### PR DESCRIPTION
Might undo this later, if it complicates more than it helps.
Since the interfaces used, all already use generic constraints, it is implicitely given for wildcard generics.