### PR TITLE
Add eventbus for general events

### DIFF
--- a/src/main/java/org/visab/eventbus/EventBusBase.java
+++ b/src/main/java/org/visab/eventbus/EventBusBase.java
@@ -1,0 +1,104 @@
+package org.visab.eventbus;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.visab.util.VISABUtil;
+
+/**
+ * @param <T> The type of the interface of the events to publish by this bus
+ */
+public abstract class EventBusBase<T extends IEvent>  {
+
+    // Logger needs .class for each class to use for log traces
+    protected Logger logger = LogManager.getLogger(this.getClass());
+
+    /**
+     * The current subscribers.
+     */
+    protected Map<String, ArrayList<ISubscriber<?>>> subscribers = new HashMap<>();
+
+    /**
+     * Casts the subscribers to their concrete EventType. If this throws an error,
+     * your subscriber class was passed the wrong event class at initialization.
+     * 
+     * @param <TEvent>            The type of event to cast to
+     * @param uncastedSubscribers The uncasted subscribers
+     * @return A list of subscribers casted to TEvent
+     */
+    @SuppressWarnings("unchecked")
+    protected <TEvent extends T> List<ISubscriber<T>> castSubscribers(
+            List<ISubscriber<?>> uncastedSubscribers) {
+        var casted = new ArrayList<ISubscriber<T>>();
+
+        for (var sub : uncastedSubscribers)
+            casted.add((ISubscriber<T>) sub);
+
+        return casted;
+    }
+
+    /**
+     * Notifies all subscribers that are subscribed to TEvent of the given event.
+     * Also notifies subscribers of the interface type T.
+     * 
+     * @param <TEvent> The type of the event
+     * @param event    The event that subscribers will be notified with
+     */
+    public <TEvent extends T> void publish(TEvent event) {
+        var concreteEventName = event.getClass().getName();
+
+        // Gets the name of the first interfaces that the event implements.
+        // We can safely assume that our event implements atleast IApiEvent due to the generic constrict.
+        var interfaceEventName = VISABUtil.getAllInterfaces(event.getClass()).get(0).getName();
+
+        // Notify concrete subscribers.
+        if (subscribers.containsKey(concreteEventName)) {
+            // Make a copy, since the subscribers list will be modified if the event is of
+            // type SessionClosedEvent.
+            var concreteSubscribers = this.<TEvent>castSubscribers(subscribers.get(concreteEventName));
+            for (var sub : concreteSubscribers)
+                sub.notify(event);
+        }
+
+        // Notify interface subscribers.
+        if (subscribers.containsKey(interfaceEventName)) {
+            var interfaceSubscribers = this.<TEvent>castSubscribers(subscribers.get(interfaceEventName));
+            for (var sub : interfaceSubscribers)
+                sub.notify(event);
+        }
+    }
+
+    /**
+     * Adds a subscriber to the busses subscribers.
+     * 
+     * @param subscriber The subscriber to add
+     */
+    public void subscribe(ISubscriber<?> subscriber) {
+        var eventType = subscriber.getSubscribedEventType();
+
+        if (!subscribers.containsKey(eventType))
+            subscribers.put(eventType, new ArrayList<ISubscriber<?>>());
+
+        // Only add if not already subscribed
+        if (!subscribers.get(eventType).contains(subscriber))
+            subscribers.get(eventType).add(subscriber);
+    }
+
+    /**
+     * Removes a subscriber from the busses subscribers.
+     * 
+     * @param subscriber The subscriber to remove
+     */
+    public void unsubscribe(ISubscriber<?> subscriber) {
+        var eventType = subscriber.getSubscribedEventType();
+
+        if (subscribers.containsKey(eventType))
+            subscribers.get(eventType).remove(subscriber);
+        else
+            logger.warn("Tried to remove subscriber that wasnt subscribed.");
+    }
+}

--- a/src/main/java/org/visab/eventbus/GeneralEventBus.java
+++ b/src/main/java/org/visab/eventbus/GeneralEventBus.java
@@ -1,0 +1,22 @@
+package org.visab.eventbus;
+
+public class GeneralEventBus extends EventBusBase<IEvent> {
+
+    /**
+     * Singelton instance
+     */
+    private static GeneralEventBus instance;
+
+    /**
+     * Gets the singelton instance
+     * 
+     * @return The instance
+     */
+    public static GeneralEventBus getInstance() {
+        if (instance == null)
+            instance = new GeneralEventBus();
+
+        return instance;
+    }
+
+}

--- a/src/main/java/org/visab/eventbus/event/VISABFileSavedEvent.java
+++ b/src/main/java/org/visab/eventbus/event/VISABFileSavedEvent.java
@@ -1,0 +1,24 @@
+package org.visab.eventbus.event;
+
+import org.visab.eventbus.IEvent;
+import org.visab.globalmodel.IVISABFile;
+
+public class VISABFileSavedEvent implements IEvent {
+
+    private IVISABFile file;
+    private boolean bySessionListener;
+
+    public VISABFileSavedEvent(IVISABFile file, boolean bySessionListener) {
+        this.file = file;
+        this.bySessionListener = bySessionListener;
+    }
+
+    public IVISABFile getFile() {
+        return file;
+    }
+
+    public boolean isBySessionListener() {
+        return bySessionListener;
+    }
+
+}

--- a/src/main/java/org/visab/eventbus/event/VISABFileViewedEvent.java
+++ b/src/main/java/org/visab/eventbus/event/VISABFileViewedEvent.java
@@ -1,0 +1,18 @@
+package org.visab.eventbus.event;
+
+import org.visab.eventbus.IEvent;
+import org.visab.globalmodel.IVISABFile;
+
+public class VISABFileViewedEvent implements IEvent {
+
+    private IVISABFile file;
+
+    public VISABFileViewedEvent(IVISABFile file) {
+        this.file = file;
+    }
+
+    public IVISABFile getFile() {
+        return file;
+    }
+
+}


### PR DESCRIPTION
Adds an eventbus for general events.
These are all events that aren't created by api calls.
We could need something to communicate when files are saved or viewed.
Main use case currently would be the visab mainpage needing to know of the recently added files / viewed files.
Since this should also be updated during runtime (e.g. during session a file is created, the mainpage has to know that) this was the first idea that came to my mind.
Maybe one of you has another approach in which we don't need another eventbus.