### PR TITLE
B fix threading in views

### DIFF
--- a/src/main/java/org/visab/newgui/DialogHelper.java
+++ b/src/main/java/org/visab/newgui/DialogHelper.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import de.saxsys.mvvmfx.FluentViewLoader;
 import de.saxsys.mvvmfx.FxmlView;
 import de.saxsys.mvvmfx.ViewModel;
+import de.saxsys.mvvmfx.ViewTuple;
 import javafx.scene.Scene;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -157,6 +158,27 @@ public class DialogHelper {
         return stage;
     }
 
+    /**
+     * TODO: Add parameters for blocking or not blocking etc. Note: same method
+     * existent in DynamicViewLoader.
+     * 
+     * @param viewTuple
+     * @param title
+     */
+    private static void showView(ViewTuple<? extends FxmlView<? extends ViewModel>, ViewModel> viewTuple, String title,
+            GenericScope scope, double minHeight, double minWidth) {
+        // TODO: Get the style here
+        var parent = viewTuple.getView();
+        var stage = new Stage();
+        stage.setTitle(title);
+        stage.setScene(new Scene(parent));
+        stage.setMinHeight(minHeight);
+        stage.setMinWidth(minWidth);
+        scope.setStage(stage);
+        stage.setOnCloseRequest(e -> scope.invokeOnStageClosed(stage));
+        stage.show();
+    }
+
     public void showView(Class<? extends FxmlView<? extends ViewModel>> viewType, String title, boolean blockWindows) {
         getStage(viewType, title, blockWindows, null).show();
     }
@@ -171,6 +193,9 @@ public class DialogHelper {
     public void showView(Class<? extends FxmlView<? extends ViewModel>> viewType, String title, boolean blockWindows,
             ViewModel viewModel) {
         var stage = getStage(viewType, title, blockWindows, viewModel);
+        var scope = new GenericScope();
+        stage.setOnCloseRequest(e -> scope.invokeOnStageClosed(stage));
+        scope.setStage(stage);
         stage.show();
     }
 
@@ -183,12 +208,11 @@ public class DialogHelper {
 
     public void showView(Class<? extends FxmlView<? extends ViewModel>> viewType, String title, boolean blockWindows,
             double minHeight, double minWidth) {
-        var stage = getStage(viewType, title, blockWindows, null);
+        var scope = new GenericScope();
 
-        stage.setMinWidth(minWidth);
-        stage.setMinHeight(minHeight);
-
-        stage.show();
+        // Resolve the session overview view
+        var viewTuple = FluentViewLoader.fxmlView(viewType).providedScopes(scope).load();
+        showView(viewTuple, title, scope, minHeight, minWidth);
     }
 
     public void showView(Class<? extends FxmlView<? extends ViewModel>> viewType, String title, boolean blockWindows,

--- a/src/main/java/org/visab/newgui/GenericScope.java
+++ b/src/main/java/org/visab/newgui/GenericScope.java
@@ -1,0 +1,40 @@
+package org.visab.newgui;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import de.saxsys.mvvmfx.Scope;
+import javafx.stage.Stage;
+
+/**
+ * Generic scope that can be used for injection to enable any view in the GUI to
+ * have onStageClose events with Consumers as their handlers.
+ * 
+ * @author leonr
+ *
+ */
+public class GenericScope implements Scope {
+
+    private Stage stage;
+    private List<Consumer<Stage>> stageClosingHandlers = new ArrayList<>();
+
+    public void invokeOnStageClosed(Stage stage) {
+        for (var consumer : stageClosingHandlers) {
+            consumer.accept(stage);
+        }
+    }
+
+    public void registerOnStageClosing(Consumer<Stage> closingHandler) {
+        stageClosingHandlers.add(closingHandler);
+    }
+
+    public Stage getStage() {
+        return stage;
+    }
+
+    public void setStage(Stage stage) {
+        this.stage = stage;
+    }
+
+}

--- a/src/main/java/org/visab/newgui/sessionoverview/view/NewSessionOverviewView.java
+++ b/src/main/java/org/visab/newgui/sessionoverview/view/NewSessionOverviewView.java
@@ -7,15 +7,12 @@ import org.visab.newgui.sessionoverview.viewmodel.NewSessionOverviewViewModel;
 
 import de.saxsys.mvvmfx.FxmlView;
 import de.saxsys.mvvmfx.InjectViewModel;
-import javafx.application.Platform;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.Label;
 import javafx.scene.control.ScrollPane;
 
 public class NewSessionOverviewView implements FxmlView<NewSessionOverviewViewModel>, Initializable {
-
-    private Thread updateLoop;
 
     @FXML
     private Label webApiAdressLabel;
@@ -59,35 +56,11 @@ public class NewSessionOverviewView implements FxmlView<NewSessionOverviewViewMo
         sessionsTimeoutedLabel.textProperty().bindBidirectional(viewModel.getTimeoutedSessionsProperty());
         sessionsCanceledLabel.textProperty().bindBidirectional(viewModel.getCanceledSessionsProperty());
 
-        startUpdateLoop();
-    }
-
-    public void startUpdateLoop() {
-        updateLoop = new Thread() {
-            @Override
-            public void run() {
-                while (true) {
-                    if (!this.isInterrupted()) {
-                        Platform.runLater(new Runnable() {
-                            @Override
-                            public void run() {
-                                viewModel.getSortedSessionGrid(scrollPane);
-                            }
-                        });
-                        try {
-                            Thread.sleep(1000);
-                        } catch (InterruptedException e) {
-                            Thread.currentThread().interrupt();
-                        }
-                    }
-                }
-            }
-        };
-        updateLoop.start();
+        viewModel.startUpdateLoop(scrollPane);
     }
 
     public void stopUpdateLoop() {
-        updateLoop.interrupt();
+        viewModel.stopUpdateLoop();
     }
 
 }

--- a/src/main/java/org/visab/newgui/sessionoverview/viewmodel/NewSessionOverviewViewModel.java
+++ b/src/main/java/org/visab/newgui/sessionoverview/viewmodel/NewSessionOverviewViewModel.java
@@ -15,11 +15,14 @@ import org.visab.eventbus.GeneralEventBus;
 import org.visab.eventbus.ISubscriber;
 import org.visab.eventbus.event.VISABFileSavedEvent;
 import org.visab.globalmodel.SessionStatus;
+import org.visab.newgui.GenericScope;
 import org.visab.newgui.ViewModelBase;
 import org.visab.newgui.control.CustomSessionObject;
 import org.visab.workspace.Workspace;
 
+import de.saxsys.mvvmfx.InjectScope;
 import de.saxsys.mvvmfx.utils.commands.Command;
+import javafx.application.Platform;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleDoubleProperty;
@@ -36,6 +39,11 @@ import javafx.scene.layout.GridPane;
 public class NewSessionOverviewViewModel extends ViewModelBase {
 
     private int gridColSize;
+
+    private Thread updateLoop;
+
+    @InjectScope
+    GenericScope scope;
 
     private class FileSavedSubscriber implements ISubscriber<VISABFileSavedEvent> {
 
@@ -91,6 +99,11 @@ public class NewSessionOverviewViewModel extends ViewModelBase {
      * Called after the instance was constructed by javafx/mvvmfx.
      */
     public void initialize() {
+
+        scope.registerOnStageClosing(stage -> {
+            stopUpdateLoop();
+        });
+
         try {
             this.webApiAdressProperty.set(Inet4Address.getLocalHost().getHostAddress() + ":"
                     + Workspace.getInstance().getConfigManager().getWebApiPort());
@@ -99,6 +112,36 @@ public class NewSessionOverviewViewModel extends ViewModelBase {
             e.printStackTrace();
         }
 
+    }
+
+    public void startUpdateLoop(ScrollPane scrollPane) {
+        updateLoop = new Thread() {
+            @Override
+            public void run() {
+                while (true) {
+                    if (!this.isInterrupted()) {
+                        Platform.runLater(new Runnable() {
+                            @Override
+                            public void run() {
+                                getSortedSessionGrid(scrollPane);
+                            }
+                        });
+                        try {
+                            Thread.sleep(1000);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                    } else {
+                        break;
+                    }
+                }
+            }
+        };
+        updateLoop.start();
+    }
+
+    public void stopUpdateLoop() {
+        updateLoop.interrupt();
     }
 
     public Command createDummySessionsCommand(ScrollPane scrollPane) {

--- a/src/main/java/org/visab/newgui/visualize/cbrshooter/viewmodel/CBRShooterReplayViewModel.java
+++ b/src/main/java/org/visab/newgui/visualize/cbrshooter/viewmodel/CBRShooterReplayViewModel.java
@@ -119,7 +119,9 @@ public class CBRShooterReplayViewModel extends ReplayViewModelBase<CBRShooterFil
 
         // Update loop eventually needs to be stopped on stage close
         scope.registerOnStageClosing(stage -> {
-            updateLoop.interrupt();
+            if (updateLoop != null) {
+                updateLoop.interrupt();
+            }
         });
 
         // Default update interval of 0.1 seconds

--- a/src/main/java/org/visab/newgui/visualize/cbrshooter/viewmodel/CBRShooterReplayViewModel.java
+++ b/src/main/java/org/visab/newgui/visualize/cbrshooter/viewmodel/CBRShooterReplayViewModel.java
@@ -116,6 +116,12 @@ public class CBRShooterReplayViewModel extends ReplayViewModelBase<CBRShooterFil
      * Called after the instance was constructed by javafx/mvvmfx.
      */
     public void initialize() {
+
+        // Update loop eventually needs to be stopped on stage close
+        scope.registerOnStageClosing(stage -> {
+            updateLoop.interrupt();
+        });
+
         // Default update interval of 0.1 seconds
         updateInterval = 100;
         selectedFrame = 0;
@@ -591,9 +597,12 @@ public class CBRShooterReplayViewModel extends ReplayViewModelBase<CBRShooterFil
             updateLoop = new Thread() {
                 @Override
                 public void run() {
+
                     // Iterate over frames and constantly update data
                     for (int i = selectedFrame; i < data.size(); i++) {
                         if (!this.isInterrupted()) {
+                            System.out.println(
+                                    "Updating data in replay view, frame: " + i + ", data size: " + (data.size() - 1));
                             // Always hold the update UI information
                             // This way is necessary, because UI changes are not allowed from another thread
                             Platform.runLater(new Runnable() {
@@ -613,11 +622,14 @@ public class CBRShooterReplayViewModel extends ReplayViewModelBase<CBRShooterFil
                                 // Exception is thrown when the stop button interrupts this thread
                                 Thread.currentThread().interrupt();
                             }
+                        } else {
+                            break;
                         }
                     }
                 }
             };
 
+            System.out.println("Starting update loop!");
             updateLoop.start();
         });
         return playData;
@@ -625,7 +637,7 @@ public class CBRShooterReplayViewModel extends ReplayViewModelBase<CBRShooterFil
 
     public Command pauseData() {
         pauseData = runnableCommand(() -> {
-            logger.debug("Interrupting match data update loop.");
+            System.out.println("Interrupting match data update loop.");
             updateLoop.interrupt();
         });
         return pauseData;


### PR DESCRIPTION
Due to the fact that the continuous updates of the session overview and the replay view 
are based on a threaded logic, we needed handling for onStageClosed events to shutdown the 
pending java processes as soon as the user simply "closes the window". 

This PR introduces a `GenericScope` which can be injected into view models that need some 
handling on stage close and the DialogHelper which is called to display the session overview 
now has a similar method to show a view like the `DynamicViewLoader` so that the scope 
injection is properly supported also for "non-visualizer-views". 

The implementation itself is not clean yet, but we do a refactoring anyway. 

This is a working version, we always may jump back to, if we find no better solution. 

Only adding for notice, merging right away because this stabilizes VISAB rather than breaking something.